### PR TITLE
Local 환경 terraform 버전이랑 CI/CD 버전 일치시키기

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.5
+          terraform_version: 1.12.2
 
       - name: Terraform Init
         run: terraform -chdir=${{ env.TF_DIR }} init


### PR DESCRIPTION
Local에선 문제 없는 코드가 CI/CD 파이프라인 과정에서 문제 발생. 따라서, 버전 일치시켜줌.