### PR TITLE
terraform backend 하드코딩으로 작성

### DIFF
--- a/dev/terraform.tf
+++ b/dev/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "finguard-infra-terraform"
-    key            = "terraform/${local.env}/terraform.tfstate"
+    key            = "terraform/dev/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform-lock"
     region         = "ap-northeast-2"

--- a/main/terraform.tf
+++ b/main/terraform.tf
@@ -3,7 +3,7 @@ terraform {
 
   backend "s3" {
     bucket         = "finguard-infra-terraform"
-    key            = "terraform/${local.env}/terraform.tfstate"
+    key            = "terraform/prod/terraform.tfstate"
     encrypt        = true
     dynamodb_table = "terraform-lock"
     region         = "ap-northeast-2"


### PR DESCRIPTION
terraform의 backend는 init 시점에서 동작하며 local, var 등 참조가 불가능하다. 따라서, local 변수로 쓰지 않고 직접 리터럴로 작성한다.