### PR TITLE
리소스 별로 각자 보안 그룹 가지도록 수정

### DIFF
--- a/dev/locals.tf
+++ b/dev/locals.tf
@@ -14,6 +14,7 @@ locals {
     lambda      = 21
     elasticache = 31
     endpoint    = 41
+    ml          = 51
   }
 
   # subnet function (az index → 0=a, 1=c)
@@ -68,6 +69,17 @@ locals {
     }
     "${local.project_name}-${local.env}-vpc-endpoint-c" = {
       cidr_block = cidrsubnet(local.main_vpc_cidr_block, 8, local.subnet_base_indexes.endpoint + 1)
+      az         = "${local.region}c"
+    }
+  }
+
+  ml_subnets = {
+    "${local.project_name}-${local.env}-vpc-endpoint-a" = {
+      cidr_block = cidrsubnet(local.main_vpc_cidr_block, 8, local.subnet_base_indexes.ml + 0)
+      az         = "${local.region}a"
+    }
+    "${local.project_name}-${local.env}-vpc-endpoint-c" = {
+      cidr_block = cidrsubnet(local.main_vpc_cidr_block, 8, local.subnet_base_indexes.ml + 1)
       az         = "${local.region}c"
     }
   }

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -42,7 +42,7 @@ module "trading_rds" {
   project_name      = local.project_name
   env               = local.env
   subnet_ids        = module.network.rds_subnet_ids
-  rds_sg_id         = module.network.sg_public
+  rds_sg_id         = module.network.sg_rds
   db_username       = local.db_username
   db_password       = data.aws_ssm_parameter.db_password.value
   public_accessible = true
@@ -54,7 +54,7 @@ module "trading_rds_proxy" {
   project_name                     = local.project_name
   env                              = local.env
   subnet_ids                       = module.network.rds_subnet_ids
-  rds_proxy_sg_id                  = module.network.sg_public
+  rds_proxy_sg_id                  = module.network.sg_rds_proxy
   rds_proxy_secret_access_role_arn = module.iam.rds_proxy_secret_access_role_arn
   rds_secret_arn                   = module.trading_rds.rds_secret_arn
   rds_identifier                   = module.trading_rds.rds_identifier
@@ -73,7 +73,7 @@ module "caching" {
   cluster_id        = "account"
   project_name      = local.project_name
   env               = local.env
-  security_group_id = module.network.sg_public
+  security_group_id = module.network.sg_elasticache
   subnet_ids        = module.network.elasticache_subnet_ids
   node_type         = local.caching.node_type
   num_cache_nodes   = local.caching.num_cache_nodes

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -9,6 +9,7 @@ module "network" {
   lambda_subnets      = local.lambda_subnets
   elasticache_subnets = local.elasticache_subnets
   endpoint_subnets    = local.endpoint_subnets
+  ml_subnets          = local.ml_subnets
 }
 
 module "iam" {

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -64,9 +64,14 @@ output "sg_sqs_vpc_endpoint" {
   value       = aws_security_group.sqs_vpc_endpoint.id
 }
 
-output "sg_alert_lambda" {
-  description = "Alert Lambda Security Group ID"
-  value       = aws_security_group.notification_sender.id
+output "sg_fraud_checker" {
+  description = "sagemaker에서 위법 여부를 확인할 컴퓨팅 리소스의 보안 그룹"
+  value       = aws_security_group.fraud_checker.id
+}
+
+output "sg_ml_endpoint" {
+  description = "sagemaker의 엔드포인트에서 사용할 보안그룹"
+  value       = aws_security_group.ml_server.id
 }
 
 output "sg_dynamodb_vpc_endpoint" {

--- a/modules/network/routes.tf
+++ b/modules/network/routes.tf
@@ -14,6 +14,21 @@ resource "aws_route_table" "private_with_dynamodb" {
   }
 }
 
+resource "aws_route_table" "private_with_s3" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-${var.env}-private-with-s3"
+  }
+}
+
+resource "aws_route_table_association" "s3" {
+  for_each = aws_subnet.ml_subnets
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private_with_s3.id
+}
+
 resource "aws_route_table_association" "dynamodb" {
   for_each = aws_subnet.lambda_subnets
 

--- a/modules/network/routes.tf
+++ b/modules/network/routes.tf
@@ -41,3 +41,10 @@ resource "aws_route_table_association" "igw" {
   subnet_id      = each.value.id
   route_table_id = aws_route_table.public_rt.id
 }
+
+resource "aws_route_table_association" "dev_rds" {
+  for_each = var.env == "dev" ? aws_subnet.rds_subnets : {}
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public_rt.id
+}

--- a/modules/network/security_groups.tf
+++ b/modules/network/security_groups.tf
@@ -78,6 +78,16 @@ resource "aws_vpc_security_group_ingress_rule" "rds_from_proxy" {
   ip_protocol                  = "tcp"
 }
 
+resource "aws_vpc_security_group_ingress_rule" "rds_from_public" {
+  count = var.env == "dev" ? 1 : 0
+
+  security_group_id = aws_security_group.rds.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 3306
+  to_port           = 3306
+  ip_protocol       = "tcp"
+}
+
 resource "aws_vpc_security_group_ingress_rule" "rds_proxy_from_backend" {
   security_group_id            = aws_security_group.rds_proxy.id
   referenced_security_group_id = aws_security_group.backend.id

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -52,3 +52,14 @@ resource "aws_subnet" "endpoint_subnets" {
     Name = each.key
   }
 }
+
+resource "aws_subnet" "ml_subnets" {
+  for_each = var.ml_subnets
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value.cidr_block
+  availability_zone = each.value.az
+  tags = {
+    Name = each.key
+  }
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -57,3 +57,11 @@ variable "endpoint_subnets" {
   }))
   description = "VPC Endpoint가 속할 서브넷들. key는 서브넷의 이름이 된다."
 }
+
+variable "ml_subnets" {
+  type = map(object({
+    cidr_block = string
+    az         = string
+  }))
+  description = "ML 서버가 속할 서브넷들. key는 서브넷의 이름이 된다."
+}

--- a/modules/network/vpc_endpoints.tf
+++ b/modules/network/vpc_endpoints.tf
@@ -46,6 +46,41 @@ resource "aws_vpc_endpoint" "sqs" {
   }
 }
 
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id             = aws_vpc.main.id
+  service_name       = "com.amazonaws.ap-northeast-2.ecr.api"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [for s in aws_subnet.endpoint_subnets : s.id]
+  security_group_ids = [aws_security_group.ecr_vpc_endpoint.id]
+  tags = {
+    Name = "${var.project_name}-${var.env}-ecr-api"
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id             = aws_vpc.main.id
+  service_name       = "com.amazonaws.ap-northeast-2.ecr.dkr"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [for s in aws_subnet.endpoint_subnets : s.id]
+  security_group_ids = [aws_security_group.ecr_vpc_endpoint.id]
+  tags = {
+    Name = "${var.project_name}-${var.env}-ecr-dkr"
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-2.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = [
+    aws_route_table.private_with_s3.id
+  ]
+
+  tags = {
+    Name = "${var.project_name}-${var.env}-s3-endpoint"
+  }
+}
+
 resource "aws_vpc_endpoint" "dynamodb" {
   vpc_id            = aws_vpc.main.id
   service_name      = "com.amazonaws.ap-northeast-2.dynamodb"


### PR DESCRIPTION
각 리소스가 동일한 public 보안 그룹을 사용하도록 통일했습니다. 그런데, 다른 보안그룹들에서 이미 아웃바운드로 각 리소스 별 보안그룹을 타겟으로 설정하여 통신이 안되는 문제가 생겼습니다. 따라서, 이전 로직으로 각 보안 그룹을 가지되 RDS 한정하여 개발환경에서 0.0.0.0/0 인바운드를 허용하도록 설정했습니다.